### PR TITLE
Reworked parameter passing to module in lxc_container

### DIFF
--- a/molecule/lxc/inventory/group_vars/containers.yml
+++ b/molecule/lxc/inventory/group_vars/containers.yml
@@ -6,21 +6,24 @@ pve_api_password: '{{ hostvars["pve"]["pve_root_password"] }}'
 # Prefix to differentiate between the provided and our generated template images
 lxcostemplate_custom_prefix: custom-
 
-lxccreate_node: pve # Must be the same as the host that the role is executed on
-lxccreate_cores: 2
-lxccreate_cpus: 1
-lxccreate_cpuunits: 1024
-lxccreate_memory: 1024
-lxccreate_swap: 0
-lxccreate_disk: "10"
-lxccreate_storage: local-lvm
-lxccreate_mounts: {}
-lxccreate_onboot: no
+lxccreate_args:
+  node: pve # Must be the same as the host that the role is executed on
+  cores: 2
+  cpuunits: 1024
+  memory: 1024
+  swap: 0
+  disk: "10"
+  storage: local-lvm
+  nameserver: "8.8.8.8,8.8.4.4"
+  searchdomain: "localdomain"
+  pubkey: '{{ lookup("file", "~/.ssh/id_rsa.pub") }}'
+  unprivileged: yes
+  timeout: 120
+  netif:
+    # Host-only network for controller/PVE/Container communication (ansible-guests)
+    net0: 'name=eth0,bridge=vmbr0,ip={{ hostonly_ip }},firewall=0'
+    # Regular Virtualbox NAT for internet access (guests-NAT)
+    net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+
 lxccreate_ostemplate_download: yes
-lxccreate_nameserver: "8.8.8.8,8.8.4.4"
-lxccreate_searchdomain: "localdomain"
-lxccreate_password: a-secret-password
-lxccreate_pubkey: '{{ lookup("file", "~/.ssh/id_rsa.pub") }}'
-lxccreate_unprivileged: yes
-lxccreate_timeout: 120
 lxccreate_bootstrap: yes

--- a/molecule/lxc/inventory/group_vars/custom_containers.yml
+++ b/molecule/lxc/inventory/group_vars/custom_containers.yml
@@ -6,21 +6,24 @@ pve_api_password: '{{ hostvars["pve"]["pve_root_password"] }}'
 # Prefix to differentiate between the provided and our generated template images
 lxcostemplate_custom_prefix: custom-
 
-lxccreate_node: pve # Must be the same as the host that the role is executed on
-lxccreate_cores: 2
-lxccreate_cpus: 1
-lxccreate_cpuunits: 1024
-lxccreate_memory: 1024
-lxccreate_swap: 0
-lxccreate_disk: "10"
-lxccreate_storage: local-lvm
-lxccreate_mounts: {}
-lxccreate_onboot: no
+lxccreate_args:
+  node: pve # Must be the same as the host that the role is executed on
+  cores: 2
+  cpuunits: 1024
+  memory: 1024
+  swap: 0
+  disk: "10"
+  storage: local-lvm
+  nameserver: "8.8.8.8,8.8.4.4"
+  searchdomain: "localdomain"
+  pubkey: '{{ lookup("file", "~/.ssh/id_rsa.pub") }}'
+  unprivileged: yes
+  timeout: 120
+  netif:
+    # Host-only network for controller/PVE/Container communication (ansible-guests)
+    net0: 'name=eth0,bridge=vmbr0,ip={{ hostonly_ip }},firewall=0'
+    # Regular Virtualbox NAT for internet access (guests-NAT)
+    net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+
 lxccreate_ostemplate_download: yes
-lxccreate_nameserver: "8.8.8.8,8.8.4.4"
-lxccreate_searchdomain: "localdomain"
-lxccreate_password: a-secret-password
-lxccreate_pubkey: '{{ lookup("file", "~/.ssh/id_rsa.pub") }}'
-lxccreate_unprivileged: yes
-lxccreate_timeout: 120
 lxccreate_bootstrap: yes

--- a/molecule/lxc/inventory/host_vars/192.168.111.200.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.200.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: template-ubuntu-20-04
 lxccreate_ostemplate: local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.200/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.200/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.201.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.201.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: template-centos-8
 lxccreate_ostemplate: local:vztmpl/centos-8-default_20191016_amd64.tar.xz
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.201/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.201/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.202.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.202.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: template-centos-7
 lxccreate_ostemplate: local:vztmpl/centos-7-default_20190926_amd64.tar.xz
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.202/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.202/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.203.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.203.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: template-debian-10
 lxccreate_ostemplate: local:vztmpl/debian-10-standard_10.5-1_amd64.tar.gz
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.203/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.203/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.204.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.204.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: template-fedora-32
 lxccreate_ostemplate: local:vztmpl/fedora-32-default_20200430_amd64.tar.xz
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.204/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.204/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.205.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.205.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: template-suse-15-2
 lxccreate_ostemplate: local:vztmpl/opensuse-15.2-default_20200824_amd64.tar.xz
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.205/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.205/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.206.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.206.yml
@@ -1,11 +1,3 @@
 lxccreate_hostname: template-archlinux
 lxccreate_ostemplate: local:vztmpl/archlinux-base_20200508-1_amd64.tar.gz
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.206/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
-
-# Variables to use for the container created from the custom template
-lxccreate_custom_hostame: '{{ lxcostemplate_custom_prefix }}{{ lxccreate_hostname }}'
-lxccreate_custom_ostemplate: '{{ lxcostemplate_custom_prefix.split("/").0 }}/{{ lxcostemplate_custom_prefix }}{{ lxcostemplate_custom_prefix.split("/").1 }}'
+hostonly_ip: 192.168.111.206/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.207.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.207.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: template-alpine-3-12
 lxccreate_ostemplate: local:vztmpl/alpine-3.12-default_20200823_amd64.tar.xz
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.207/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.207/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.220.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.220.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: '{{ lxcostemplate_custom_prefix }}ubuntu-20-04'
 lxccreate_ostemplate: 'local:vztmpl/{{ lxcostemplate_custom_prefix }}ubuntu-20.04-standard_20.04-1_amd64.tar.gz'
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.220/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.220/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.221.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.221.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: '{{ lxcostemplate_custom_prefix }}centos-8'
 lxccreate_ostemplate: 'local:vztmpl/{{ lxcostemplate_custom_prefix }}centos-8-default_20191016_amd64.tar.gz'
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.221/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.221/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.222.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.222.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: '{{ lxcostemplate_custom_prefix }}centos-7'
 lxccreate_ostemplate: 'local:vztmpl/{{ lxcostemplate_custom_prefix }}centos-7-default_20190926_amd64.tar.gz'
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.222/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.222/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.223.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.223.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: '{{ lxcostemplate_custom_prefix }}debian-10'
 lxccreate_ostemplate: 'local:vztmpl/{{ lxcostemplate_custom_prefix }}debian-10-standard_10.5-1_amd64.tar.gz'
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.223/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.223/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.224.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.224.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: '{{ lxcostemplate_custom_prefix }}fedora-32'
 lxccreate_ostemplate: 'local:vztmpl/{{ lxcostemplate_custom_prefix }}fedora-32-default_20200430_amd64.tar.gz'
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.224/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.224/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.225.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.225.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: '{{ lxcostemplate_custom_prefix }}suse-15-2'
 lxccreate_ostemplate: 'local:vztmpl/{{ lxcostemplate_custom_prefix }}opensuse-15.2-default_20200824_amd64.tar.gz'
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.225/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.225/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.226.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.226.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: '{{ lxcostemplate_custom_prefix }}archlinux'
 lxccreate_ostemplate: 'local:vztmpl/{{ lxcostemplate_custom_prefix }}archlinux-base_20200508-1_amd64.tar.gz'
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.226/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.226/24

--- a/molecule/lxc/inventory/host_vars/192.168.111.227.yml
+++ b/molecule/lxc/inventory/host_vars/192.168.111.227.yml
@@ -1,7 +1,3 @@
 lxccreate_hostname: '{{ lxcostemplate_custom_prefix }}alpine-3-12'
 lxccreate_ostemplate: 'local:vztmpl/{{ lxcostemplate_custom_prefix }}alpine-3.12-default_20200823_amd64.tar.gz'
-lxccreate_netif:
-  # Host-only network for controller/PVE/Container communication (ansible-guests)
-  net0: name=eth0,bridge=vmbr0,ip=192.168.111.227/24,firewall=0
-  # Regular Virtualbox NAT for internet access (guests-NAT)
-  net1: name=eth1,bridge=vmbr1,ip=dhcp,firewall=0
+hostonly_ip: 192.168.111.227/24

--- a/roles/lxc_container/README.md
+++ b/roles/lxc_container/README.md
@@ -54,9 +54,6 @@ Generic example:
     # Parameters for the container that you want to create
     lxccreate_hostname: a-hostname
     lxccreate_ostemplate: local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz
-    lxccreate_netif:
-      net0: name=eth0,bridge=vmbr0,ip=192.168.1.10/24,gw=192.168.1.1,firewall=0
-    lxccreate_password: a-root-password
 ```
 
 Creating a batch of containers based on an inventory is also possible using a customized inventory. An example layout is show below:
@@ -70,14 +67,13 @@ all:
         192.168.1.123:
           # Variables unique to every container
           lxccreate_hostname: ct-a
-          lxccreate_netif:
-            net0: name=eth0,bridge=vmbr0,ip=192.168.1.123/24,gw=192.168.1.1,firewall=0
           ...
         192.168.1.124:
         ...
       # Common variables shared between containers
       lxccreate_ostemplate: local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz
-      lxccreate_cores: 4
+      lxccreate_args:
+        cores: 4
       # PVE connection variables
       pve_api_user: root@pam
       pve_api_password: some-secret-password

--- a/roles/lxc_container/defaults/main.yml
+++ b/roles/lxc_container/defaults/main.yml
@@ -1,44 +1,46 @@
 ---
 # This role needs API and SSH access to a PVE node with become privileges
 # in order to create a container. Please set pve_host to the corresponding
-# inventory hostname
+# host present in the inventory
 pve_host: pve.example.com
 pve_api_host: '{{ pve_host }}'
 pve_api_user: root@pam
 pve_api_password: mypassword
 
-# The parameters of the container. See
-# https://docs.ansible.com/ansible/latest/modules/proxmox_module.html
-# for details about each parameter
-# The PVE node to create the container on
-lxccreate_node: pve # Must be the same as the host that the role is executed on
+# Hostname of the new container
 lxccreate_hostname: my-container
-lxccreate_cores: 1
-lxccreate_cpus: 1
-lxccreate_cpuunits: 1024
-lxccreate_memory: 1024
-lxccreate_swap: 0
-lxccreate_disk: "10"
-lxccreate_storage: local-lvm
-lxccreate_mounts: {}
-lxccreate_onboot: no
-# Use this ostemplate (base image) to create the container
-lxccreate_ostemplate: local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz
+lxccreate_ostemplate: 'local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz'
 # Automatically download the specified base template from the PVE repository if the image is not present
 lxccreate_ostemplate_download: yes
-# Dict of network interfaces. See the PVE API for all valid parameters
-# https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/lxc
-lxccreate_netif:
-  net0: name=eth0,bridge=vmbr0,ip=192.168.1.10/24,gw=192.168.1.1,firewall=0
-lxccreate_nameserver: "8.8.8.8,8.8.4.4"
-lxccreate_searchdomain: "localdomain"
-lxccreate_password: a-secret-password
-lxccreate_pubkey: '{{ lookup("file", "~/.ssh/id_rsa.pub") }}'
-lxccreate_unprivileged: yes
+
+# Additional arguments to be passed to the proxmox module
+# for when creating the container. See
+# https://docs.ansible.com/ansible/latest/modules/proxmox_module.html
+# for details about each parameter
+lxccreate_args:
+  node: pve
+  cores: 1
+  #cpus: 1
+  cpuunits: 1024
+  memory: 1024
+  swap: 0
+  disk: "10"
+  storage: local-lvm
+  #mounts: {}
+  onboot: no
+  # Dict of network interfaces. See the PVE API for all valid parameters
+  # https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/lxc
+  netif:
+    net0: name=eth0,bridge=vmbr0,ip=dhcp,firewall=0
+  #nameserver: "8.8.8.8,8.8.4.4"
+  #searchdomain: "localdomain"
+  #password: a-secret-password # Uncomment if you want a root password
+  pubkey: '{{ lookup("file", "~/.ssh/id_rsa.pub") }}'
+  unprivileged: yes
 
 # Increase this value if you are experiencing timeout errors during PVE API tasks
 lxccreate_timeout: 120
 
-# Set this to no if you want to skip bootstrapping the container
-# (ssh server, python)
+# Set this to yes to run a simple bootstrap script on the container after creation.
+# The script will prepare the container for Ansible (SSH server + Python)
 lxccreate_bootstrap: yes

--- a/roles/lxc_container/tasks/main.yml
+++ b/roles/lxc_container/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: Generate module argument dict [1/2]
+  set_fact:
+    lxccreate_special_args:
+      api_host: '{{ pve_api_host }}'
+      api_user: '{{ pve_api_user }}'
+      api_password: '{{ pve_api_password }}'
+      hostname: '{{ lxccreate_hostname }}'
+      ostemplate: '{{ lxccreate_ostemplate }}'
+      timeout:  '{{ lxccreate_timeout }}'
+- name: Generate module argument dict [2/2]
+  set_fact:
+    lxccreate_module_args: '{{ lxccreate_args | combine(lxccreate_special_args) }}'
+
 - include: ostemplate.yml
   delegate_to: '{{ pve_host }}'
 - include: provision.yml

--- a/roles/lxc_container/tasks/provision.yml
+++ b/roles/lxc_container/tasks/provision.yml
@@ -1,27 +1,5 @@
 - name: Container is present
-  proxmox:
-    api_user: '{{ pve_api_user }}'
-    api_password: '{{ pve_api_password }}'
-    api_host: '{{ pve_api_host }}'
-    cores: '{{ lxccreate_cores }}'
-    cpus: '{{ lxccreate_cpus }}'
-    cpuunits: '{{ lxccreate_cpuunits }}'
-    memory: '{{ lxccreate_memory }}'
-    swap: '{{ lxccreate_swap }}'
-    disk: '{{ lxccreate_disk }}'
-    storage: '{{ lxccreate_storage }}'
-    mounts: '{{ lxccreate_mounts }}'
-    onboot: '{{ lxccreate_onboot }}'
-    nameserver: '{{ lxccreate_nameserver }}'
-    searchdomain: '{{ lxccreate_searchdomain }}'
-    password: '{{ lxccreate_password }}'
-    pubkey: '{{ lxccreate_pubkey }}'
-    unprivileged: '{{ lxccreate_unprivileged }}'
-    hostname: '{{ lxccreate_hostname }}'
-    ostemplate: '{{ lxccreate_ostemplate }}'
-    netif: '{{ lxccreate_netif }}'
-    node: '{{ lxccreate_node }}'
-    timeout: '{{ lxccreate_timeout }}'
+  proxmox: '{{ lxccreate_module_args }}'
   delegate_to: localhost
   register: pve_lxccreate_task
 - name: Wait for PVE API sync


### PR DESCRIPTION
Previously, each possible argument for the proxmox module called
by the lxc_container role was a separate top-level role variable.
This made it impossible to omit unwanted parameters (such as the
password for the root user) from the creation API call. As the PVE
API treats undefined parameters differently from empty parameters,
thic meant that certain actions were not possible through the role.

For example, if the user did not want to set a root password, they
could not set the lxccreate_password role to '!' or '', as the PVE
API would not accept such a value. Omitting the password entirely
is allowed however and will result in the root password being
disabled - the desired behavior in this case.

To account for situations like these, the role variables have been
reworked significantly. All non-essential module arguments are now
collected in a single dict 'lxccreate_args' and then passed to
the proxmox module along with a few other things like API information.
The goal of this change is to allow for more flexibility, both now
and in the future: It allows useres to fully control which parameters
should be set during container creation.

Unfortunatly, this change is utterly incompaible with the old method,
which means that a major version bump is required.