### PR TITLE
ci: fix tags not pointing to release commits

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,15 +35,18 @@ jobs:
         run: |
           sed -i '/version: */c\version: ${{ github.event.inputs.version }}' galaxy.yml
 
-      - name: Commit and push Release
+      - name: Create and push Release commit
         run: |
           git add galaxy.yml
           git commit -m "Release ${{ github.event.inputs.version }}"
           git push
 
+      - name: Get release commit hash
+        run: echo "release_hash=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
       - name: Build Ansible Collection
         run: ansible-galaxy collection build --force
-
+  
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
@@ -51,10 +54,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ github.event.inputs.version }}
+          commitish: ${{ env.release_hash }}
           release_name: ${{ github.event.inputs.version }}
           draft: false
           prerelease: false
-
+                
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Until now, the release tags always pointed to the last commit before
the actual release (the commit including the galaxy.yml)
update, apparently due to the create-release action using the last commithash
at the time of checkout, which happens at the beginning of the workflow,
thus ignoring the new release commit. This commit fixes that behavior
by explicitly setting the commit hash to the hash of the release commit.